### PR TITLE
fix: npm start가 안되는 오류 수정

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,4 +1,5 @@
-import { CracoAliasPlugin } from 'react-app-alias';
+/* eslint-disable */
+const { CracoAliasPlugin } = require('react-app-alias');
 
 module.exports = {
   plugins: [

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src"]
+      "@/*": ["src/*"]
     }
   }
 }


### PR DESCRIPTION
## Issue

- 

## Details

- craco.config.js에 import가 안돼서 require로 바꿨습니다.
- eslint 오류가 발생해서 해당 파일에만 오류가 나지 않도록 했습니다.


