### PR TITLE
feat: 통계 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from '@/pages/Home';
 import Event from '@/pages/Event';
 import Badge from '@/pages/Badge';
 import Detail from '@/pages/Detail';
+import Statistics from '@/pages/Statistics';
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route path='/event' element={<Event />} />
         <Route path='/event/:id' element={<Detail />} />
         <Route path='/badge' element={<Badge />} />
+        <Route path='/statistics' element={<Statistics />} />
       </Routes>
     </ThemeProvider>
   );

--- a/src/apis/api/like.ts
+++ b/src/apis/api/like.ts
@@ -17,3 +17,14 @@ export const delLike = async (id: number) => {
     throw error;
   }
 };
+
+export const getLikeList = async (page: number) => {
+  try {
+    const {data} = await baseAPI.get('/users/me/likes', {
+      params: {page, size: 10},
+    });
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/assets/types/achievement.ts
+++ b/src/assets/types/achievement.ts
@@ -1,0 +1,13 @@
+export interface AchievedProps {
+  name: string;
+  count: number;
+  percentage: number;
+}
+
+export interface AchievementProps {
+  subtitle?: string;
+  total?: number;
+  type?: string;
+  color: string;
+  data: AchievedProps;
+}

--- a/src/assets/types/event.ts
+++ b/src/assets/types/event.ts
@@ -1,16 +1,14 @@
 export interface EventProps {
   id: number;
   title: string;
-  category: string;
-  district: string;
+  category?: string;
+  district?: string;
   place: string;
   startDate: string;
   endDate: string;
-  isFree: boolean;
+  isFree?: boolean;
   mainImg: string;
-  latitude: number;
-  longitude: number;
-  isLiked: boolean;
+  isLiked?: boolean;
   isVisited?: boolean;
   visitCount?: number;
   likeCount?: number;
@@ -23,6 +21,9 @@ export interface EventDetailProps extends EventProps {
   etcDesc: string;
   orgName: string;
   orgLink: string;
+  category: string;
+  latitude: number;
+  longitude: number;
 }
 
 export interface EventListProps {

--- a/src/components/Event/EventItem.tsx
+++ b/src/components/Event/EventItem.tsx
@@ -4,25 +4,16 @@ import date from '@/assets/img/date.svg';
 import {useNavigate} from 'react-router-dom';
 import {EventProps} from '@/assets/types/event';
 
-function EventItem({
-  id,
-  title,
-  category,
-  district,
-  place,
-  startDate,
-  endDate,
-  isFree,
-  mainImg,
-  latitude,
-  longitude,
-  isVisited,
-}: EventProps) {
+interface ItemProps {
+  data: EventProps;
+}
+
+function EventItem({data}: ItemProps) {
   const navigate = useNavigate();
 
   const dateFormat = () => {
-    const startDateFormatted = startDate.split('T')[0];
-    const endDateFormatted = endDate.split('T')[0];
+    const startDateFormatted = data.startDate.split('T')[0];
+    const endDateFormatted = data.endDate.split('T')[0];
 
     if (startDateFormatted === endDateFormatted) {
       return startDateFormatted;
@@ -31,23 +22,31 @@ function EventItem({
   };
 
   return (
-    <EventItemContainer onClick={() => navigate(`/event/${id}`)}>
-      <MainImage src={mainImg} alt='mainImage' />
+    <EventItemContainer onClick={() => navigate(`/event/${data.id}`)}>
+      <MainImage
+        src={data.mainImg}
+        alt='mainImage'
+        $isSimple={data.category === undefined}
+      />
       <EventContent>
-        <FilterList>
-          <FilterItem>{category}</FilterItem>
-          <FilterItem>{isFree === true ? '무료' : '유료'}</FilterItem>
-        </FilterList>
-        <EventTitle>{title}</EventTitle>
+        {data.category && (
+          <FilterList>
+            <FilterItem>{data.category}</FilterItem>
+            <FilterItem>{data.isFree === true ? '무료' : '유료'}</FilterItem>
+          </FilterList>
+        )}
+        <EventTitle>{data.title}</EventTitle>
         <EventPlace>
           <Location width='14px' height='14px' />
-          <div>{place}</div>
+          <div>{data.place}</div>
         </EventPlace>
         <EventDate>
           <img src={date} alt='date' />
           <div>{dateFormat()}</div>
         </EventDate>
-        <CheckInButton>방문하기</CheckInButton>
+        {data.isVisited !== undefined && (
+          <CheckInButton>방문하기</CheckInButton>
+        )}
       </EventContent>
     </EventItemContainer>
   );
@@ -59,14 +58,14 @@ const EventItemContainer = styled.div`
   gap: 1.2rem;
   width: 100%;
   height: fit-content;
-  padding-bottom: 1.2rem;
+  padding: 1.2rem 0;
   border-bottom: 0.8px solid ${props => props.theme.colors.neutral4};
   cursor: pointer;
 `;
 
-const MainImage = styled.img`
-  width: 10rem;
-  height: 13rem;
+const MainImage = styled.img<{$isSimple: boolean}>`
+  width: ${props => (props.$isSimple ? '8rem' : '10rem')};
+  height: ${props => (props.$isSimple ? '10rem' : '13rem')};
   background-color: ${props => props.theme.colors.neutral5};
   border-radius: 0.4rem;
   flex-shrink: 0;

--- a/src/components/Event/EventList.tsx
+++ b/src/components/Event/EventList.tsx
@@ -65,7 +65,7 @@ function EventList() {
         </ErrorMessage>
       )}
       {data?.pages.map(page =>
-        page.events.map(event => <EventItem key={event.id} {...event} />),
+        page.events.map(event => <EventItem key={event.id} data={event} />),
       )}
       <div ref={ref} style={{height: '1px'}} />
       {isFetchingNextPage && (
@@ -85,7 +85,7 @@ const EventListContainer = styled.div`
   width: 100%;
   height: 100%;
   margin: auto;
-  padding: 0.8rem 1.6rem 0.1rem 1.6rem;
+  padding: 0 1.6rem 0.1rem 1.6rem;
   gap: 1.2rem;
 `;
 

--- a/src/components/Statistics/Count.tsx
+++ b/src/components/Statistics/Count.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+interface CountProps {
+  title: string;
+  count: number;
+  isMonth?: boolean;
+}
+
+function Count({title, count, isMonth = false}: CountProps) {
+  return (
+    <CountWrap $isMonth={isMonth}>
+      <p>{title}</p>
+      {count}회
+    </CountWrap>
+  );
+}
+
+const CountWrap = styled.button<{$isMonth: boolean}>`
+  width: 100%;
+  height: 7.5rem;
+  color: ${props => props.theme.colors.neutral1};
+  font-size: ${props => props.theme.sizes.xl};
+  font-weight: bold;
+  background-color: ${props =>
+    props.$isMonth ? '#f0fdf4' : props.theme.colors.secondary};
+  border-radius: 8px;
+  padding: 1.2rem;
+  text-align: left;
+
+  & p {
+    font-size: ${props => props.theme.sizes.s};
+    font-weight: normal;
+    color: ${props => props.theme.colors.primary};
+  }
+`;
+
+export default Count;

--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 import styled from 'styled-components';
 import {QueryFunctionContext, useInfiniteQuery} from '@tanstack/react-query';
 import {useInView} from 'react-intersection-observer';
@@ -8,7 +8,6 @@ import EventItem from '../Event/EventItem';
 import EventItemSkeleton from '../Event/EventItemSkeleton';
 
 function LikeList() {
-  const [list, setList] = useState<EventListProps>();
   const [ref, inView] = useInView();
 
   const getList = async ({pageParam}: QueryFunctionContext) => {
@@ -16,7 +15,7 @@ function LikeList() {
     return data;
   };
 
-  const {data, isFetchingNextPage, fetchNextPage, hasNextPage, status} =
+  const {data, isFetchingNextPage, fetchNextPage, status} =
     useInfiniteQuery<EventListProps>({
       queryKey: ['events'],
       queryFn: getList,

--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -1,0 +1,81 @@
+import {useEffect, useState} from 'react';
+import styled from 'styled-components';
+import {QueryFunctionContext, useInfiniteQuery} from '@tanstack/react-query';
+import {useInView} from 'react-intersection-observer';
+import {getLikeList} from '@/apis/api/like';
+import {EventListProps} from '@/assets/types/event';
+import EventItem from '../Event/EventItem';
+import EventItemSkeleton from '../Event/EventItemSkeleton';
+
+function LikeList() {
+  const [list, setList] = useState<EventListProps>();
+  const [ref, inView] = useInView();
+
+  const getList = async ({pageParam}: QueryFunctionContext) => {
+    const data = await getLikeList(pageParam as number);
+    return data;
+  };
+
+  const {data, isFetchingNextPage, fetchNextPage, hasNextPage, status} =
+    useInfiniteQuery<EventListProps>({
+      queryKey: ['events'],
+      queryFn: getList,
+      getNextPageParam: lastPage =>
+        lastPage.currentPage < lastPage.totalPages
+          ? lastPage.currentPage + 1
+          : undefined,
+      initialPageParam: 1,
+      retry: 0,
+    });
+
+  useEffect(() => {
+    if (inView) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
+  return (
+    <Container>
+      {data?.pages[0].totalCount === 0 ? (
+        <NoList>아직 관심있는 행사가 없어요.</NoList>
+      ) : (
+        <>
+          {status === 'pending' && (
+            <>
+              {Array.from({length: 10}).map((_, i) => (
+                <EventItemSkeleton key={i} />
+              ))}
+            </>
+          )}
+          {data?.pages.map(page =>
+            page.events.map(event => <EventItem key={event.id} data={event} />),
+          )}
+          {isFetchingNextPage ? (
+            <>
+              {Array.from({length: 5}).map((_, i) => (
+                <EventItemSkeleton key={`skeleton-${i}`} />
+              ))}
+            </>
+          ) : (
+            <div ref={ref} />
+          )}
+        </>
+      )}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  margin-top: 1.6rem;
+`;
+
+const NoList = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 20rem;
+  font-size: ${props => props.theme.sizes.l};
+  color: ${props => props.theme.colors.neutral2};
+`;
+
+export default LikeList;

--- a/src/components/common/Achievement.tsx
+++ b/src/components/common/Achievement.tsx
@@ -1,28 +1,24 @@
 import styled from 'styled-components';
-import {AchievedProps} from '@/pages/Badge';
+import {AchievementProps} from '@/assets/types/achievement';
 
-interface AchievementProps {
-  data: AchievedProps;
-}
-
-function Achievement({data}: AchievementProps) {
+function Achievement({subtitle, type, total, color, data}: AchievementProps) {
   const getRate = () => {
-    return Number((data.current / data.total).toFixed(1));
+    return Number((data.percentage / 100).toFixed(1));
   };
 
   return (
     <AchievementBox>
       <ContentBox>
         <TitleWrap>
-          {data.title}
-          {data.subtitle && <p>{data.subtitle}</p>}
+          {data.name}
+          {subtitle && <p>{subtitle}</p>}
         </TitleWrap>
         <Achieved>
-          {data.type ? `${data.current}/${data.total}` : `${data.current}회`}
+          {type ? `${data.count}/${total}` : `${data.count}회`}
         </Achieved>
       </ContentBox>
       <Graph>
-        <AchievedGraph $color={data.color} $rate={() => getRate()} />
+        <AchievedGraph $color={color} $rate={() => getRate()} />
       </Graph>
     </AchievementBox>
   );

--- a/src/pages/Badge.tsx
+++ b/src/pages/Badge.tsx
@@ -5,6 +5,8 @@ import BadgeItem from '@/components/Badge/BadgeItem';
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header/Header';
 import Layout from '@/components/common/Layout';
+import {basicHeight} from '@/assets/data/constant';
+import {AchievedProps} from '@/assets/types/achievement';
 
 const dummy = [
   {
@@ -70,33 +72,27 @@ export interface BadgeProps {
   img: string;
 }
 
-export interface AchievedProps {
-  title: string;
-  subtitle?: string;
-  total: number;
-  current: number;
-  type?: string;
-  color: string;
-}
-
 function Badge() {
   const [list, setList] = useState<BadgeProps[]>(dummy);
   const [achieved, setAchieved] = useState<AchievedProps>({
-    title: '서울 완전 정복',
-    subtitle: '서울 25개 구 모두 방문하기',
-    total: 25,
-    current: 14,
-    type: 'goal',
-    color: '#5D9D8A',
+    name: '서울 완전 정복',
+    count: 14,
+    percentage: 70,
   });
 
   return (
     <>
       <Header />
-      <Layout headerHeight='6.5rem'>
+      <Layout headerHeight={basicHeight}>
         <Box style={{paddingBottom: 0}}>
           <Label>다음 목표</Label>
-          <Achievement data={achieved} />
+          <Achievement
+            subtitle='서울 25개 구 모두 방문하기'
+            total={25}
+            type='goal'
+            color='#5D9D8A'
+            data={achieved}
+          />
         </Box>
         <Box>
           <Label>나의 배지</Label>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -8,6 +8,7 @@ import MainImage from '@/components/Detail/MainImage';
 import VisitedStats from '@/components/Detail/VisitedStats';
 import DetailHeader from '@/components/common/Header/DetailHeader';
 import Layout from '@/components/common/Layout';
+import {basicHeight, emptyHeight} from '@/assets/data/constant';
 
 function Detail() {
   const id = useParams().id || '0';
@@ -30,7 +31,7 @@ function Detail() {
     <>
       <DetailHeader name='행사 상세' />
       {info && (
-        <Layout headerHeight='6.5rem' footerHeight='0'>
+        <Layout headerHeight={basicHeight} footerHeight={emptyHeight}>
           <MainImage
             id={parseInt(id)}
             imageUrl={info.mainImg}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,0 +1,115 @@
+import styled from 'styled-components';
+import {basicHeight} from '@/assets/data/constant';
+import Footer from '@/components/common/Footer';
+import Header from '@/components/common/Header/Header';
+import Layout from '@/components/common/Layout';
+import {AchievedProps} from '@/assets/types/achievement';
+import {useState} from 'react';
+import Achievement from '@/components/common/Achievement';
+import Count from '@/components/Statistics/Count';
+import LikeList from '@/components/Statistics/LikeList';
+
+interface StatProps {
+  totalVisits: number;
+  thisMonthVisits: number;
+  topGenre: AchievedProps;
+  topDistrict: AchievedProps;
+  visitedGenres: string[];
+}
+
+function Statistics() {
+  const [stat, setStat] = useState<StatProps>({
+    totalVisits: 23,
+    thisMonthVisits: 8,
+    topGenre: {name: '전시/미술', count: 8, percentage: 80},
+    topDistrict: {name: '종로구', count: 5, percentage: 60},
+    visitedGenres: ['전시/미술', '클래식', '연극', '콘서트', '교육/체험'],
+  });
+
+  return (
+    <>
+      <Header />
+      <Layout headerHeight={basicHeight}>
+        <Box style={{paddingBottom: 0}}>
+          <Label>나의 발자국</Label>
+          <CountArea>
+            <Count title='총 방문 행사' count={23} />
+            <Count title='이번 달 방문' count={8} isMonth={true} />
+          </CountArea>
+          <AchievementArea>
+            <p>가장 많이 방문한 장르</p>
+            <Achievement color='#5676A5' data={stat.topGenre} />
+          </AchievementArea>
+          <AchievementArea>
+            <p>가장 많이 방문한 지역</p>
+            <Achievement color='#C1641E' data={stat.topDistrict} />
+          </AchievementArea>
+          <GenresArea>
+            <p>방문한 장르</p>
+            <GenresBox>
+              {stat.visitedGenres.map((item, idx) => (
+                <GenreWrap key={idx}>{item}</GenreWrap>
+              ))}
+            </GenresBox>
+          </GenresArea>
+        </Box>
+        <Box>
+          <Label>관심 행사</Label>
+          <LikeList />
+        </Box>
+      </Layout>
+      <Footer />
+    </>
+  );
+}
+
+const Box = styled.div`
+  width: 100%;
+  padding: 3.2rem;
+`;
+
+const Label = styled.h2`
+  font-size: ${props => props.theme.sizes.l};
+  font-weight: bold;
+  margin-bottom: 1.6rem;
+`;
+
+const CountArea = styled.div`
+  width: 100%;
+  display: flex;
+  column-gap: 1.6rem;
+  margin-bottom: 2.5rem;
+`;
+
+const AchievementArea = styled.div`
+  width: 100%;
+  margin-bottom: 2rem;
+
+  & p {
+    font-size: ${props => props.theme.sizes.m};
+    margin-bottom: 1.5rem;
+  }
+`;
+
+const GenresArea = styled.div`
+  & p {
+    font-size: ${props => props.theme.sizes.m};
+    margin-bottom: 1.5rem;
+  }
+`;
+
+const GenresBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+`;
+
+const GenreWrap = styled.div`
+  padding: 0.8rem 1.5rem;
+  background-color: ${props => props.theme.colors.secondary};
+  color: ${props => props.theme.colors.primary};
+  font-size: ${props => props.theme.sizes.s};
+  border-radius: 25px;
+`;
+
+export default Statistics;


### PR DESCRIPTION
## Issue

- #21 

## Details

- 관심 행사 목록 조회 api까지 연결됐습니다.
  - 무한 스크롤까지 구현됐습니다.
- EventItem 컴포넌트를 최대한 활용하기 위해 전달되는 props에 따라 표시되는 데이터가 달라지도록 수정했습니다.
- EventItem 컴포넌트에 property를 하나하나 따로 전달하지 않고 객체 형태로 전달되도록 변경했습니다.
- 실제 데이터 필드에 맞게 달성도 그래프 관련 타입을 수정했습니다. (/types/achievement.ts)
- 상수화된 헤더, 푸터 높이를 사용하도록 수정했습니다.