### PR TITLE
feat: 배지 api 연결

### DIFF
--- a/src/apis/api/users.ts
+++ b/src/apis/api/users.ts
@@ -3,6 +3,7 @@ import {baseAPI, baseURL} from '../instance';
 import {useAuthStore, User} from '@/store/user';
 import {useEffect} from 'react';
 import {StatProps} from '@/assets/types/achievement';
+import {getBadgeListWithImg} from '../services/users';
 
 export const loginOauth = (provider: 'kakao' | 'naver') => {
   window.location.href = `${baseURL}/oauth2/authorization/${provider}`;
@@ -58,6 +59,31 @@ export const deleteUser = async () => {
 export const getStatistics = async () => {
   try {
     const response = await baseAPI.get<StatProps>('/users/me/statistics');
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const getBadgeList = async () => {
+  try {
+    const response = await baseAPI.get('/users/me/badges');
+    return getBadgeListWithImg(response.data.badges);
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const useGetBadgeList = () => {
+  return useQuery({
+    queryKey: ['badges'],
+    queryFn: () => getBadgeList(),
+  });
+};
+
+export const getNextGoal = async () => {
+  try {
+    const response = await baseAPI.get('/users/me/badges/next');
     return response.data;
   } catch (error) {
     throw error;

--- a/src/apis/services/users.ts
+++ b/src/apis/services/users.ts
@@ -1,0 +1,14 @@
+import {BadgeProps} from '@/assets/types/badge';
+import {badgeImg} from '@/assets/data/badgeImg';
+
+export const getBadgeListWithImg = (data: BadgeProps[]) => {
+  data.forEach(item => {
+    const findImg = badgeImg.find(img => img.code === item.code.toLowerCase());
+    if (findImg) {
+      item.imgUrl = findImg.imgUrl;
+    } else {
+      item.imgUrl = null;
+    }
+  });
+  return data;
+};

--- a/src/assets/data/badgeImg.ts
+++ b/src/assets/data/badgeImg.ts
@@ -1,0 +1,137 @@
+export const badgeImg = [
+  {
+    code: 'concert_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102992/concert_explorer_chhhld.png',
+  },
+  {
+    code: 'play_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102993/play_explorer_tsnxhs.png',
+  },
+  {
+    code: 'classic_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102993/class_explorer_hzvkss.png',
+  },
+  {
+    code: 'culture_class_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102993/cultural_class_explorer_nira5c.png',
+  },
+  {
+    code: 'dance_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102994/dance_explorer_vyde7i.png',
+  },
+  {
+    code: 'solo_performance_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102994/solo_performance_explorer_gtn8bp.png',
+  },
+  {
+    code: 'etc_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102997/etc_explorer_w19mtd.png',
+  },
+  {
+    code: 'exhibition_art_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102998/exhibition_art_explorer_updcz4.png',
+  },
+  {
+    code: 'festival_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102998/festival_explorer_frcknl.png',
+  },
+  {
+    code: 'korean_tradition_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102999/koream_tradition_explorer_aljrum.png',
+  },
+  {
+    code: 'first_visit',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103000/first_visit_cifupr.png',
+  },
+  {
+    code: 'seoul_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746102999/seoul_explorer_ainzq6.png',
+  },
+  {
+    code: 'movie_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103002/movie_explorer_wlc5ju.png',
+  },
+  {
+    code: 'musical_opera_explorer',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103003/musical_opera_explorer_ckislg.png',
+  },
+  {
+    code: 'seoul_master',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103004/seoul_master_ndvt6j.png',
+  },
+  {
+    code: 'classic_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103004/classic_mania_rj1tze.png',
+  },
+  {
+    code: 'concert_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103004/concert_mania_qmhyty.png',
+  },
+  {
+    code: 'culture_class_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103004/culture_class_mania_q4v6yz.png',
+  },
+  {
+    code: 'dance_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103008/dance_mania_f3vfjl.png',
+  },
+  {
+    code: 'korean_tradition_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103009/korean_tradition_mania_ia7oon.png',
+  },
+  {
+    code: 'exhibition_art_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103009/exhibition_art_mania_cvqbkp.png',
+  },
+  {
+    code: 'festival_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103009/festival_mania_ht13ii.png',
+  },
+  {
+    code: 'etc_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103008/etc_mania_gohwgg.png',
+  },
+  {
+    code: 'movie_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103010/movie_mania_nbzm6j.png',
+  },
+  {
+    code: 'musical_opera_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103013/musical_opera_mania_piwhl2.png',
+  },
+  {
+    code: 'solo_performance_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103013/solo_performance_mania_wblntu.png',
+  },
+  {
+    code: 'play_mania',
+    imgUrl:
+      'https://res.cloudinary.com/df6cxoj9b/image/upload/v1746103014/play_mania_ldd5l4.png',
+  },
+];

--- a/src/assets/types/badge.ts
+++ b/src/assets/types/badge.ts
@@ -1,0 +1,23 @@
+export interface BadgeProps {
+  id: number;
+  badgeType: boolean;
+  code: string;
+  name: string;
+  description: string;
+  imgUrl: string | null;
+  owned: boolean;
+}
+
+export interface BadgeImgProps {
+  code: string;
+  imgUrl: string;
+}
+
+export interface NextBadgeProps {
+  id: number;
+  code: string;
+  name: string;
+  description: string;
+  progress: number;
+  target: number;
+}

--- a/src/components/Badge/BadgeItem.tsx
+++ b/src/components/Badge/BadgeItem.tsx
@@ -1,13 +1,28 @@
-import {BadgeProps} from '@/pages/Badge';
 import styled from 'styled-components';
+import {BadgeProps} from '@/assets/types/badge';
+import {usePopupStore} from '@/store/popup';
 
-function BadgeItem({isDone, name, img}: BadgeProps) {
+interface BadgeItemProps {
+  data: BadgeProps;
+}
+
+function BadgeItem({data}: BadgeItemProps) {
+  const {openPopup} = usePopupStore();
+
+  const handleClick = () => {
+    openPopup({
+      name: data.name,
+      imgUrl: data.imgUrl || '',
+      description: data.description,
+    });
+  };
+
   return (
-    <ItemWrap>
-      <ContentWrap $isDone={isDone}>
-        <ImgWrap src={img} />
+    <ItemWrap onClick={handleClick}>
+      <ContentWrap $isDone={data.owned}>
+        <ImgWrap src={data.imgUrl || ''} />
       </ContentWrap>
-      <NameWrap>{name}</NameWrap>
+      <NameWrap>{data.name}</NameWrap>
     </ItemWrap>
   );
 }
@@ -18,6 +33,7 @@ const ItemWrap = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  cursor: pointer;
 `;
 
 const ContentWrap = styled.div<{$isDone: boolean}>`
@@ -40,8 +56,8 @@ const ContentWrap = styled.div<{$isDone: boolean}>`
 `;
 
 const ImgWrap = styled.img`
-  width: 6rem;
-  height: 6rem;
+  width: 7rem;
+  height: 7rem;
   object-fit: cover;
   border-radius: 50%;
 `;

--- a/src/components/Badge/BadgeItemSkeleton.tsx
+++ b/src/components/Badge/BadgeItemSkeleton.tsx
@@ -1,0 +1,47 @@
+import {SkeletonAnimation} from '@/styles/common';
+import styled from 'styled-components';
+
+function BadgeItemSkeleton() {
+  return (
+    <SkeletonContainer>
+      <SkeletonContent>
+        <SkeletonImage />
+      </SkeletonContent>
+      <SkeletonName />
+    </SkeletonContainer>
+  );
+}
+
+const SkeletonContainer = styled.div`
+  width: 10rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SkeletonContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid ${props => props.theme.colors.neutral4};
+  border-radius: 8px;
+  width: 100%;
+  height: 10rem;
+  margin-bottom: 0.5rem;
+`;
+
+const SkeletonImage = styled.div`
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  ${SkeletonAnimation};
+`;
+
+const SkeletonName = styled.div`
+  width: 90%;
+  height: 2rem;
+  ${SkeletonAnimation};
+`;
+
+export default BadgeItemSkeleton;

--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+import ReactDOM from 'react-dom';
+import {basicHeight} from '@/assets/data/constant';
+import {usePopupStore} from '@/store/popup';
+
+function Popup() {
+  const {isOpen, data, closePopup} = usePopupStore();
+
+  if (!isOpen || !data) return null;
+
+  return ReactDOM.createPortal(
+    <>
+      <PopupBackground onClick={closePopup} />
+      <Container>
+        <ImgWrap src={data.imgUrl} alt='badge' />
+        <NameWrap>{data.name}</NameWrap>
+        <DescriptionWrap>{data.description}</DescriptionWrap>
+      </Container>
+    </>,
+    document.body,
+  );
+}
+
+const PopupBackground = styled.div`
+  position: fixed;
+  bottom: ${basicHeight};
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: inherit;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 10;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: inherit;
+  height: 26rem;
+  position: fixed;
+  bottom: ${basicHeight};
+  background-color: white;
+  padding: 1.5rem;
+  z-index: 11;
+  border-radius: 25px 25px 0 0;
+  animation: popupEffect 0.2s linear;
+
+  @keyframes popupEffect {
+    from {
+      bottom: -${basicHeight};
+    }
+    to {
+      bottom: ${basicHeight};
+    }
+  }
+`;
+
+const ImgWrap = styled.img`
+  width: 12rem;
+  height: 12rem;
+  padding: 1rem;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid ${props => props.theme.colors.neutral4};
+  margin-bottom: 1.5rem;
+`;
+
+const NameWrap = styled.div`
+  font-size: ${props => props.theme.sizes.xl};
+  font-weight: bold;
+  margin-bottom: 2.5rem;
+`;
+
+const DescriptionWrap = styled.div`
+  font-size: ${props => props.theme.sizes.m};
+  color: ${props => props.theme.colors.neutral2};
+`;
+
+export default Popup;

--- a/src/store/popup.ts
+++ b/src/store/popup.ts
@@ -1,0 +1,29 @@
+import {create} from 'zustand';
+
+interface PopupData {
+  name: string;
+  imgUrl: string;
+  description: string;
+}
+
+interface PopupState {
+  isOpen: boolean;
+  data: PopupData | null;
+  openPopup: (data: PopupData) => void;
+  closePopup: () => void;
+}
+
+export const usePopupStore = create<PopupState>(set => ({
+  isOpen: false,
+  data: null,
+  openPopup: (data: PopupData) =>
+    set({
+      isOpen: true,
+      data,
+    }),
+  closePopup: () =>
+    set({
+      isOpen: false,
+      data: null,
+    }),
+}));


### PR DESCRIPTION


## Issue

- #44 

## Details

- 배지 리스트 조회 api 연결했습니다.
- 다음 목표 조회 api 연결했습니다.
- 팝업을 추가했습니다.
  - zustand로 팝업 상태 관리하도록 했습니다.
- 배지 이미지 데이터를 추가했습니다.
  - 응답으로 받은 데이터와 저장된 데이터를 비교해 이미지 주소를 가져오는 로직을 추가했습니다. (services/users.ts)
- BadgeItemSkeleton을 추가했습니다.
