### PR TITLE
perf: 배지 이미지 로딩 ux 개선

### DIFF
--- a/src/components/Badge/BadgeItem.tsx
+++ b/src/components/Badge/BadgeItem.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import {BadgeProps} from '@/assets/types/badge';
 import {usePopupStore} from '@/store/popup';
+import {useEffect, useState} from 'react';
+import {SkeletonImage} from './BadgeItemSkeleton';
 
 interface BadgeItemProps {
   data: BadgeProps;
@@ -8,6 +10,13 @@ interface BadgeItemProps {
 
 function BadgeItem({data}: BadgeItemProps) {
   const {openPopup} = usePopupStore();
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const img = new Image();
+    img.onload = () => setLoaded(true);
+    img.src = data.imgUrl || '';
+  }, [data.imgUrl]);
 
   const handleClick = () => {
     openPopup({
@@ -20,7 +29,11 @@ function BadgeItem({data}: BadgeItemProps) {
   return (
     <ItemWrap onClick={handleClick}>
       <ContentWrap $owned={data.owned}>
-        <ImgWrap src={data.imgUrl || ''} $owned={data.owned} loading='lazy' />
+        {loaded ? (
+          <ImgWrap src={data.imgUrl || ''} $owned={data.owned} loading='lazy' />
+        ) : (
+          <SkeletonImage />
+        )}
       </ContentWrap>
       <NameWrap>{data.name}</NameWrap>
     </ItemWrap>

--- a/src/components/Badge/BadgeItemSkeleton.tsx
+++ b/src/components/Badge/BadgeItemSkeleton.tsx
@@ -31,7 +31,7 @@ const SkeletonContent = styled.div`
   margin-bottom: 0.5rem;
 `;
 
-const SkeletonImage = styled.div`
+export const SkeletonImage = styled.div`
   width: 7rem;
   height: 7rem;
   border-radius: 50%;


### PR DESCRIPTION
## Issue

- #77

## Details

- 이미지가 로드 되기 전까지 스켈레톤 컴포넌트를 보여주도록 수정했습니다.
