### PR TITLE
fix: 데이터 캐싱 관련 오류 해결

### DIFF
--- a/src/apis/api/event.ts
+++ b/src/apis/api/event.ts
@@ -86,7 +86,7 @@ const fetchFootPrints = async (bounds: boundsProps) => {
 
 export const useGetFootPrints = (bounds: boundsProps) => {
   return useQuery({
-    queryKey: ['events', bounds],
+    queryKey: ['footprints', bounds],
     queryFn: () => fetchFootPrints(bounds),
     enabled:
       bounds.maxLat !== null &&

--- a/src/apis/api/event.ts
+++ b/src/apis/api/event.ts
@@ -102,7 +102,7 @@ export const postVisit = async (
 ) => {
   try {
     const {data} = await baseAPI.post(`/events/${id}/visit`, {
-      timeout: 8000,
+      timeout: 20000,
       latitude,
       longitude,
     });

--- a/src/apis/api/event.ts
+++ b/src/apis/api/event.ts
@@ -70,6 +70,7 @@ export const useGetEventDetail = (id: number) => {
         return getEventDetailWithStatus(id);
       }
     },
+    staleTime: isGuest ? 1000 * 60 * 5 : 0,
   });
 };
 

--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -25,7 +25,6 @@ function LikeList() {
           ? lastPage.currentPage + 1
           : undefined,
       initialPageParam: 1,
-      retry: 0,
     });
 
   useEffect(() => {

--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -31,7 +31,7 @@ function LikeList() {
     if (inView) {
       fetchNextPage();
     }
-  }, [inView]);
+  }, [fetchNextPage, inView]);
 
   return (
     <Container>

--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -18,7 +18,7 @@ function LikeList() {
 
   const {data, isFetchingNextPage, fetchNextPage, status} =
     useInfiniteQuery<EventListProps>({
-      queryKey: ['events'],
+      queryKey: ['likes'],
       queryFn: getList,
       getNextPageParam: lastPage =>
         lastPage.currentPage < lastPage.totalPages

--- a/src/pages/VisitedList.tsx
+++ b/src/pages/VisitedList.tsx
@@ -42,7 +42,6 @@ function VisitedList() {
           ? lastPage.currentPage + 1
           : undefined,
       initialPageParam: 1,
-      retry: 0,
     });
 
   useEffect(() => {


### PR DESCRIPTION
## Issue

- #76 

## Details

- 좋아요 api 호출 시 행사 상세 정보, 좋아요 목록 데이터를 refetch하도록 했습니다.
- 좋아요 목록, 지도 api query key 값 수정했습니다.
- 로그인 하지 않았을 때 행사 상세 조회 stale time을 추가했습니다.
- 좋아요/방문 목록 쿼리 retry를 기본값으로 변경했습니다.
- 방문 인증 timeout 시간을 20초로 늘렸습니다.
