### PR TITLE
perf: 관심 행사, 방문 행사 스크롤 유지

### DIFF
--- a/src/components/Statistics/LikeList.tsx
+++ b/src/components/Statistics/LikeList.tsx
@@ -4,12 +4,14 @@ import {QueryFunctionContext, useInfiniteQuery} from '@tanstack/react-query';
 import {useInView} from 'react-intersection-observer';
 import {getLikeList} from '@/apis/api/like';
 import {EventListProps} from '@/assets/types/event';
+import {useScrollStore} from '@/store/eventList';
 import EventItem from '../Event/EventItem';
 import EventItemSkeleton from '../Event/EventItemSkeleton';
 import NoList from '../common/NoList';
 
 function LikeList() {
   const [ref, inView] = useInView();
+  const {scrollY} = useScrollStore();
 
   const getList = async ({pageParam}: QueryFunctionContext) => {
     const data = await getLikeList(pageParam as number);
@@ -32,6 +34,12 @@ function LikeList() {
       fetchNextPage();
     }
   }, [fetchNextPage, inView]);
+
+  useEffect(() => {
+    if (scrollY !== 0) {
+      window.scrollTo(0, scrollY);
+    }
+  }, [scrollY]);
 
   return (
     <Container>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -5,38 +5,46 @@ import badge from '@/assets/img/badge.svg';
 import statistics from '@/assets/img/statistics.svg';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {useRef} from 'react';
+import {useScrollStore} from '@/store/eventList';
 
 function Footer() {
   const navigate = useNavigate();
   const location = useLocation();
   const currentPath = useRef(location.pathname);
+  const {setScrollY} = useScrollStore();
+
+  const handleNavigation = (path: string) => {
+    setScrollY(0);
+    window.scrollTo(0, 0);
+    navigate(path);
+  };
 
   return (
     <FooterContainer>
       <NavItem
         $fillcolor={currentPath.current === '/'}
-        onClick={() => navigate('/')}
+        onClick={() => handleNavigation('/')}
       >
         <img src={map} alt='map' />
         <div>지도</div>
       </NavItem>
       <NavItem
         $fillcolor={currentPath.current === '/event'}
-        onClick={() => navigate('/event')}
+        onClick={() => handleNavigation('/event')}
       >
         <img src={event} alt='event' />
         <div>행사</div>
       </NavItem>
       <NavItem
         $fillcolor={currentPath.current === '/badge'}
-        onClick={() => navigate('/badge')}
+        onClick={() => handleNavigation('/badge')}
       >
         <img src={badge} alt='badge' />
         <div>배지</div>
       </NavItem>
       <NavItem
         $fillcolor={currentPath.current === '/statistics'}
-        onClick={() => navigate('/statistics')}
+        onClick={() => handleNavigation('/statistics')}
       >
         <img src={statistics} alt='statistics' />
         <div>통계</div>

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -5,7 +5,7 @@ export default function ScrollToTop() {
   const {pathname} = useLocation();
 
   useEffect(() => {
-    const skipRestorePaths = ['/event'];
+    const skipRestorePaths = ['/event', '/statistics', '/visited'];
 
     if (skipRestorePaths.includes(pathname)) return;
 

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -54,7 +54,7 @@ function Event() {
   };
 
   useEffect(() => {
-    if (scrollY) {
+    if (scrollY !== 0) {
       window.scrollTo(0, scrollY);
     }
   }, [scrollY]);

--- a/src/pages/VisitedList.tsx
+++ b/src/pages/VisitedList.tsx
@@ -11,6 +11,7 @@ import EventItemSkeleton from '@/components/Event/EventItemSkeleton';
 import EventItem from '@/components/Event/EventItem';
 import Layout from '@/components/common/Layout';
 import {basicHeight, emptyHeight} from '@/assets/data/constant';
+import {useScrollStore} from '@/store/eventList';
 
 const getTitle = (range: string) => {
   switch (range) {
@@ -27,6 +28,7 @@ function VisitedList() {
   const range = useParams().range || 'all';
   const title = getTitle(range || '');
   const [ref, inView] = useInView();
+  const {scrollY} = useScrollStore();
 
   const getList = async ({pageParam}: QueryFunctionContext) => {
     const data = await getVisitList(pageParam as number, range);
@@ -43,6 +45,12 @@ function VisitedList() {
           : undefined,
       initialPageParam: 1,
     });
+
+  useEffect(() => {
+    if (scrollY! == 0) {
+      window.scrollTo(0, scrollY);
+    }
+  }, [scrollY]);
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {


### PR DESCRIPTION
## Issue

- #93 

## Details

- 관심 행사, 방문 행사 목록에서 행사 상세 페이지로 갔다가 돌아왔을 때 스크롤이 유지되도록 했습니다.
- 하단 바를 통해서 페이지를 변경할 시 스크롤 초기화 및 최상단으로 이동하도록 수정했습니다. 
